### PR TITLE
Refactor cache invalidation logic and consolidate imports

### DIFF
--- a/common/db/operations.py
+++ b/common/db/operations.py
@@ -22,12 +22,7 @@ from common.db.repositories.favorite_repository import FavoriteRepository
 from common.utils.cache import CacheTTL
 from common.config import GEO_ID_MAPPING, get_key_by_value
 from common.utils.phone_parser import extract_phone_numbers_from_resource
-from common.utils.cache_invalidation import (
-    invalidate_user_caches,
-    invalidate_subscription_caches,
-    invalidate_ad_caches,
-    invalidate_favorite_caches
-)
+from common.utils.cache_managers import invalidate_favorite_caches, invalidate_subscription_caches, invalidate_user_caches
 
 from common.utils.cache_managers import (
     UserCacheManager,
@@ -36,7 +31,7 @@ from common.utils.cache_managers import (
     FavoriteCacheManager,
     BaseCacheManager
 )
-from common.utils.cache_invalidation import get_entity_cache_key
+from common.utils.cache import get_entity_cache_key
 
 logger = logging.getLogger(__name__)
 

--- a/common/db/repositories/subscription_repository.py
+++ b/common/db/repositories/subscription_repository.py
@@ -11,7 +11,7 @@ from common.db.models.user import User
 from common.utils.cache import CacheTTL
 from common.config import GEO_ID_MAPPING, get_key_by_value
 from common.utils.cache_managers import SubscriptionCacheManager, UserCacheManager, BaseCacheManager
-from common.utils.cache_invalidation import get_entity_cache_key
+from common.utils.cache import get_entity_cache_key
 
 logger = logging.getLogger(__name__)
 

--- a/services/telegram_service/app/handlers/favorites.py
+++ b/services/telegram_service/app/handlers/favorites.py
@@ -11,7 +11,7 @@ from common.db.repositories.favorite_repository import FavoriteRepository
 from common.db.repositories.user_repository import UserRepository
 from common.utils.ad_utils import get_ad_images
 from common.utils.cache_managers import FavoriteCacheManager, AdCacheManager
-from common.utils.cache_invalidation import get_entity_cache_key
+from common.utils.cache import get_entity_cache_key
 
 from ..bot import dp, bot
 

--- a/services/telegram_service/app/handlers/subscription.py
+++ b/services/telegram_service/app/handlers/subscription.py
@@ -9,7 +9,7 @@ from common.db.repositories.subscription_repository import SubscriptionRepositor
 from common.db.repositories.user_repository import UserRepository
 from common.db.models.subscription import UserFilter
 from common.utils.cache_managers import SubscriptionCacheManager, UserCacheManager
-from common.utils.cache_invalidation import get_entity_cache_key
+from common.utils.cache import get_entity_cache_key
 
 from ..bot import dp, bot
 from common.config import GEO_ID_MAPPING


### PR DESCRIPTION
Moved cache invalidation functions from `cache.py` to `cache_managers.py` to align with their relevant contexts and responsibilities. Updated imports across the codebase to reflect these changes, ensuring a cleaner and more maintainable structure.