### PR TITLE
Refactor messaging services for platform-specific initialization

### DIFF
--- a/common/messaging/task_registry.py
+++ b/common/messaging/task_registry.py
@@ -16,8 +16,7 @@ def register_platform_tasks(platform_name: str, task_module_path: str):
     """
     from common.messaging.tasks import (
         send_ad_with_extra_buttons as unified_send_ad,
-        send_subscription_notification as unified_send_notification,
-        process_show_more_description as unified_process_show_more
+        send_subscription_notification as unified_send_notification
     )
 
     # Register send_ad_with_extra_buttons

--- a/common/messaging/telegram_messaging.py
+++ b/common/messaging/telegram_messaging.py
@@ -28,7 +28,8 @@ class TelegramMessaging(MessagingInterface):
         """
         self.bot = bot
 
-    def get_platform_name(self) -> str:
+    @property
+    def platform_name(self) -> str:
         """Get platform identifier."""
         return "telegram"
 

--- a/common/messaging/viber_messaging.py
+++ b/common/messaging/viber_messaging.py
@@ -25,7 +25,8 @@ class ViberMessaging(MessagingInterface):
         """
         self.viber = viber_api
 
-    def get_platform_name(self) -> str:
+    @property
+    def platform_name(self) -> str:
         """Get platform identifier."""
         return "viber"
 

--- a/common/messaging/whatsapp_messaging.py
+++ b/common/messaging/whatsapp_messaging.py
@@ -38,7 +38,8 @@ class WhatsAppMessaging(MessagingInterface):
         if not self.from_number.startswith("whatsapp:"):
             self.from_number = f"whatsapp:{self.from_number}"
 
-    def get_platform_name(self) -> str:
+    @property
+    def platform_name(self) -> str:
         """Get platform identifier."""
         return "whatsapp"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,6 +168,7 @@ services:
     environment:
       <<: *common-variables
       TELEGRAM_TOKEN: "${TELEGRAM_TOKEN}"
+      SERVICE_NAME: "telegram"
       PYTHONPATH: "/app:/app/common"  # Important: set the correct Python path
     command: python -m app.main
 
@@ -225,6 +226,7 @@ services:
       <<: *common-variables
       VIBER_TOKEN: "${VIBER_TOKEN}"
       VIBER_WEBHOOK_URL: "${VIBER_WEBHOOK_URL}"
+      SERVICE_NAME: "viber"
     ports:
       - "8001:8000"  # Expose port for webhook
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000
@@ -294,6 +296,7 @@ services:
       TWILIO_ACCOUNT_SID: "${TWILIO_ACCOUNT_SID}"
       TWILIO_AUTH_TOKEN: "${TWILIO_AUTH_TOKEN}"
       TWILIO_PHONE_NUMBER: "${TWILIO_PHONE_NUMBER}"
+      SERVICE_NAME: "whatsapp"
     command: uvicorn app.main:app --host 0.0.0.0 --port 8080
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8080/health" ]

--- a/services/telegram_service/app/__init__.py
+++ b/services/telegram_service/app/__init__.py
@@ -1,3 +1,10 @@
 # services/telegram_service/app/__init__.py
 
+from common.messaging.service import MessagingService
+from common.messaging.telegram_messaging import TelegramMessaging
+from .bot import bot
 from . import tasks
+
+# Create telegram-specific messaging service
+messaging_service = MessagingService()
+messaging_service.register_messenger("telegram", TelegramMessaging(bot))

--- a/services/telegram_service/app/flow_integration.py
+++ b/services/telegram_service/app/flow_integration.py
@@ -15,7 +15,7 @@ from common.messaging.unified_flow import (
 logger = logging.getLogger(__name__)
 
 
-@dp.message_handler(lambda message: True, state="*", priority=100)
+@dp.message_handler(lambda message: True, state="*")
 async def flow_message_handler(message: types.Message, state: FSMContext = None):
     """
     Message handler that checks for active flows before letting other handlers process.


### PR DESCRIPTION
Replaced default initialization with a platform-specific setup using the `SERVICE_NAME` environment variable. Modularized messenger registration, improved error handling, and updated platform name retrieval with properties for consistency across services. Adjusted `docker-compose.yml` to define `SERVICE_NAME` for each platform.