### PR TITLE
Refactor `chat_id` references and extend filter options.

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -43,12 +43,18 @@ CREATE TABLE IF NOT EXISTS ad_images (
 CREATE TABLE IF NOT EXISTS user_filters (
     id SERIAL PRIMARY KEY,
     user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
-    property_type VARCHAR(50) NOT NULL,
+    property_type VARCHAR(50),
     city BIGINT,
-    rooms_count INTEGER[] NOT NULL,
+    rooms_count INTEGER[],
     price_min NUMERIC,
     price_max NUMERIC,
-    is_paused BOOLEAN NOT NULL DEFAULT FALSE
+    is_paused BOOLEAN DEFAULT FALSE,
+    floor_max INTEGER,
+    is_not_first_floor BOOLEAN,
+    is_not_last_floor BOOLEAN,
+    is_last_floor_only BOOLEAN,
+    pets_allowed BOOLEAN,
+    without_broker BOOLEAN
 );
 
 -- Add the unique constraint so that ON CONFLICT(user_id) works

--- a/services/telegram_service/app/handlers/menu_handlers.py
+++ b/services/telegram_service/app/handlers/menu_handlers.py
@@ -279,7 +279,7 @@ async def subscribe(callback_query: types.CallbackQuery, state: FSMContext):
                 "error": str(e)
             })
             await safe_send_message(
-                chat_id=callback_query.from_user.id,
+                user_id=user_db_id,
                 text="Помилка при збереженні фільтрів. Спробуйте ще раз."
             )
             await safe_answer_callback_query(callback_query.id)
@@ -287,7 +287,7 @@ async def subscribe(callback_query: types.CallbackQuery, state: FSMContext):
 
         # 1) Let user know subscription is set
         await safe_send_message(
-            chat_id=callback_query.from_user.id,
+            user_id=user_db_id,
             text="Ви успішно підписалися на пошук оголошень!"
         )
 
@@ -312,7 +312,7 @@ async def subscribe(callback_query: types.CallbackQuery, state: FSMContext):
             # We found >=3 ads in last days_limit
             message_ending = 'день' if days_limit == 1 else 'днів'
             await safe_send_message(
-                chat_id=callback_query.from_user.id,
+                user_id=user_db_id,
                 text=f"Ось вам актуальні оголошення за останні {days_limit} {message_ending}:"
             )
 
@@ -350,7 +350,7 @@ async def subscribe(callback_query: types.CallbackQuery, state: FSMContext):
                 "filters": filters
             })
             await safe_send_message(
-                chat_id=callback_query.from_user.id,
+                user_id=user_db_id,
                 text="Ваші параметри фільтру настільки унікальні, що майже немає оголошень навіть за останній місяць.\n"
                      "Спробуйте розширити параметри пошуку або зачекайте. Ми сповістимо, щойно з'являться нові оголошення."
             )
@@ -370,7 +370,7 @@ async def subscribe(callback_query: types.CallbackQuery, state: FSMContext):
         )
 
         await safe_send_message(
-            chat_id=callback_query.from_user.id,
+            user_id=user_db_id,
             text="Ми будемо надсилати вам нові оголошення, щойно вони з'являтимуться!",
             reply_markup=main_menu_keyboard()
         )

--- a/services/telegram_service/app/tasks.py
+++ b/services/telegram_service/app/tasks.py
@@ -19,14 +19,14 @@ def send_ad_with_extra_buttons(telegram_id: int, text: str, s3_image_links: str,
     # Import messaging_service here to avoid circular import
     from common.messaging.service import messaging_service
 
-    return messaging_service.send_ad_with_extra_buttons(
+    return messaging_service.send_ad(
         user_id=telegram_id,
-        platform="telegram",
-        text=text,
+        ad_data={
+            'id': ad_id,
+            'external_id': ad_external_id,
+            'resource_url': resource_url
+        },
         image_url=s3_image_links,
-        resource_url=resource_url,
-        ad_id=ad_id,
-        external_id=ad_external_id
     )
 
 


### PR DESCRIPTION
Replaced `chat_id` with `user_id` for consistent parameter naming across functions. Updated `user_filters` table to include additional filter criteria such as floor preferences, pet allowance, and broker exclusions. Simplified ad messaging logic to use a consolidated `ad_data` structure.