### PR TITLE
Refactor task routing to use common messaging service

### DIFF
--- a/services/notifier_service/app/tasks.py
+++ b/services/notifier_service/app/tasks.py
@@ -12,8 +12,8 @@ from common.utils.logging_config import log_context, log_operation, LogAggregato
 # Import the service logger
 from . import logger
 
-TELEGRAM_SEND_TASK = "telegram_service.app.tasks.send_ad_with_extra_buttons"
-
+#TELEGRAM_SEND_TASK = "telegram_service.app.tasks.send_ad_with_extra_buttons"
+TELEGRAM_SEND_TASK = "common.messaging.tasks.send_ad_with_extra_buttons"
 
 @log_operation("get_ad_images")
 def get_ad_images_local(ad):
@@ -115,7 +115,7 @@ def _notify_user_about_ad(user_id, ad, s3_image_urls):
         })
 
         shared_app.send_task(
-            "telegram_service.app.tasks.send_ad_with_extra_buttons",
+            "common.messaging.tasks.send_ad_with_extra_buttons",
             args=[user_id, text, s3_image_urls, ad.get('resource_url'), ad.get("id"), ad.get("external_id")]
         )
 

--- a/services/telegram_service/app/handlers/menu_handlers.py
+++ b/services/telegram_service/app/handlers/menu_handlers.py
@@ -340,7 +340,7 @@ async def subscribe(callback_query: types.CallbackQuery, state: FSMContext):
                     "ad_id": ad_id
                 })
                 celery_app.send_task(
-                    "telegram_service.app.tasks.send_ad_with_extra_buttons",
+                    "common.messaging.tasks.send_ad_with_extra_buttons",
                     args=args_for_celery
                 )
         else:

--- a/services/telegram_service/app/tasks.py
+++ b/services/telegram_service/app/tasks.py
@@ -12,22 +12,22 @@ from .bot import dp
 
 # Create the tasks directly without using the task registry
 # This avoids the circular import issue
-@celery_app.task(name='telegram_service.app.tasks.send_ad_with_extra_buttons')
-def send_ad_with_extra_buttons(telegram_id: int, text: str, s3_image_links: str, resource_url: str, ad_id: int,
-                               ad_external_id: str):
-    """Send ad with extra buttons to Telegram user"""
-    # Import messaging_service here to avoid circular import
-    from common.messaging.service import messaging_service
-
-    return messaging_service.send_ad(
-        user_id=telegram_id,
-        ad_data={
-            'id': ad_id,
-            'external_id': ad_external_id,
-            'resource_url': resource_url
-        },
-        image_url=s3_image_links,
-    )
+# @celery_app.task(name='telegram_service.app.tasks.send_ad_with_extra_buttons')
+# def send_ad_with_extra_buttons(telegram_id: int, text: str, s3_image_links: str, resource_url: str, ad_id: int,
+#                                ad_external_id: str):
+#     """Send ad with extra buttons to Telegram user"""
+#     # Import messaging_service here to avoid circular import
+#     from common.messaging.service import messaging_service
+#
+#     return messaging_service.send_ad(
+#         user_id=telegram_id,
+#         ad_data={
+#             'id': ad_id,
+#             'external_id': ad_external_id,
+#             'resource_url': resource_url
+#         },
+#         image_url=s3_image_links,
+#     )
 
 
 @celery_app.task(name='telegram_service.app.tasks.send_subscription_notification')


### PR DESCRIPTION
Updated task references and removed redundancy by consolidating `send_ad_with_extra_buttons` under `common.messaging.tasks`. This simplifies the codebase and avoids circular dependencies.