### PR TITLE
Refactor task handling and update Celery imports

### DIFF
--- a/services/notifier_service/app/tasks.py
+++ b/services/notifier_service/app/tasks.py
@@ -96,7 +96,6 @@ def sort_and_notify_new_ads(new_ads):
 
 @log_operation("notify_user_about_ad")
 def _notify_user_about_ad(user_id, ad, s3_image_urls):
-    from common.celery_app import celery_app as shared_app
 
     with log_context(logger, user_id=user_id, ad_id=ad.get('id')):
         text = (
@@ -114,7 +113,7 @@ def _notify_user_about_ad(user_id, ad, s3_image_urls):
             'external_id': ad.get('external_id')
         })
 
-        shared_app.send_task(
+        celery_app.send_task(
             "common.messaging.tasks.send_ad_with_extra_buttons",
             args=[user_id, text, s3_image_urls, ad.get('resource_url'), ad.get("id"), ad.get("external_id")]
         )

--- a/services/telegram_service/app/celery_app.py
+++ b/services/telegram_service/app/celery_app.py
@@ -7,6 +7,9 @@ try:
 except ImportError:
     pass  # Silently continue if error handlers module doesn't exist yet
 
+from . import tasks
+import common.messaging.tasks  # Add this line
+
 # Telegram-specific configuration
 celery_app.conf.update(
     # Throttling to respect Telegram API limits

--- a/services/telegram_service/app/tasks.py
+++ b/services/telegram_service/app/tasks.py
@@ -29,6 +29,12 @@ from .bot import dp
 #         image_url=s3_image_links,
 #     )
 
+@celery_app.task(name='telegram_service.app.tasks.send_ad_with_extra_buttons')
+def send_ad_with_extra_buttons(user_id, text, s3_image_url, resource_url, ad_id, ad_external_id):
+    # Just delegate to the common task
+    from common.messaging.tasks import send_ad_with_extra_buttons as common_send_ad
+    return common_send_ad.delay(user_id, text, s3_image_url, resource_url, ad_id, ad_external_id)
+
 
 @celery_app.task(name='telegram_service.app.tasks.send_subscription_notification')
 def send_subscription_notification(telegram_id: int, notification_type: str, data: dict):


### PR DESCRIPTION
Replaced `shared_app` with `celery_app` for task sending in notifier service for clarity. Added a new wrapper task in telegram service to delegate to the common task. Updated Celery app configuration to include necessary imports for the telegram service.